### PR TITLE
Add Visual Studio 2019 VC redist merge modules

### DIFF
--- a/images/win/scripts/Installers/Windows2019/Install-VS2019.ps1
+++ b/images/win/scripts/Installers/Windows2019/Install-VS2019.ps1
@@ -101,6 +101,7 @@ $WorkLoads = '--allWorkloads --includeRecommended ' + `
               '--add Microsoft.VisualStudio.Component.VC.MFC.ARM.Spectre ' + `
               '--add Microsoft.VisualStudio.Component.VC.MFC.ARM64 ' + `
               '--add Microsoft.VisualStudio.Component.VC.MFC.ARM64.Spectre ' + `
+              '--add Microsoft.VisualStudio.Component.VC.Redist.MSM ' + `
               '--add Microsoft.VisualStudio.Component.VC.Runtimes.ARM.Spectre ' + `
               '--add Microsoft.VisualStudio.Component.VC.Runtimes.ARM64.Spectre ' + `
               '--add Microsoft.VisualStudio.Component.VC.Runtimes.x86.x64.Spectre ' + `


### PR DESCRIPTION
Visual Studio 2019 moves the merge modules to an individual component.  They are deprecated in this release, but are still required to build MSI installers for applications built using Visual C or C++.